### PR TITLE
feat: 增加了对请求数据为列表的处理

### DIFF
--- a/app/http/validator/core/data_transfer/data_transfer.go
+++ b/app/http/validator/core/data_transfer/data_transfer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"goskeleton/app/global/variable"
 	"goskeleton/app/http/validator/core/interf"
+	"strconv"
 	"time"
 )
 
@@ -17,18 +18,27 @@ context  gin上下文
 */
 
 func DataAddContext(validatorInterface interf.ValidatorInterface, extraAddDataPrefix string, context *gin.Context) *gin.Context {
+	return DataArrayAddContext(-1,validatorInterface, extraAddDataPrefix, context)
+}
+
+// 当请求的数据为数组时，可以用此方法来为 Array[index] 数据绑定前缀
+func DataArrayAddContext(index int, validatorInterface interf.ValidatorInterface, extraAddDataPrefix string, context *gin.Context) *gin.Context {
 	var tempJson interface{}
 	if tmpBytes, err1 := json.Marshal(validatorInterface); err1 == nil {
 		if err2 := json.Unmarshal(tmpBytes, &tempJson); err2 == nil {
 			if value, ok := tempJson.(map[string]interface{}); ok {
+				extraAddDataSuffix := ""
+				if index >= 0 {
+					extraAddDataSuffix = "["+strconv.Itoa(index)+"]"
+				}
 				for k, v := range value {
-					context.Set(extraAddDataPrefix+k, v)
+					context.Set(extraAddDataPrefix+k+extraAddDataSuffix, v)
 				}
 				// 此外给上下文追加三个键：created_at  、 updated_at  、 deleted_at ，实际根据需要自己选择获取相关键值
 				curDateTime := time.Now().Format(variable.DateFormat)
-				context.Set(extraAddDataPrefix+"created_at", curDateTime)
-				context.Set(extraAddDataPrefix+"updated_at", curDateTime)
-				context.Set(extraAddDataPrefix+"deleted_at", curDateTime)
+				context.Set(extraAddDataPrefix+"created_at"+extraAddDataSuffix, curDateTime)
+				context.Set(extraAddDataPrefix+"updated_at"+extraAddDataSuffix, curDateTime)
+				context.Set(extraAddDataPrefix+"deleted_at"+extraAddDataSuffix, curDateTime)
 				return context
 			}
 		}


### PR DESCRIPTION
张馆长，你好

我在使用GinSkeleton时发现没有对请求为列表数据的处理，所以增加了相应的功能。

修改文件为 `app/http/validator/core/data_transfer/data_transfer.go`、`app/utils/data_bind/formdata_to_model.go`

使用方法为

0. 数据提交如下

![image](https://user-images.githubusercontent.com/71813586/126299693-94d1c672-a932-43cd-a60e-b9a2900e57cc.png)



1. 验证器处 —— CheckParams 函数

```
func (a Add)CheckParams(c*gin.Context)  {
	var as[]Add
	if err := c.ShouldBind(&as); err != nil{
		errs := gin.H{
			"tips": "DataFormatAdd参数校验失败，参数不符合规定，name 长度(>=1)、maxTimesPerClient 长度（）、不允许添加",
			"err":  err.Error(),
		}
		response.ErrorParam(c,errs)
		return
	}

	var extraAddBindDataContext *gin.Context
	for i:=0;i<len(as);i++{
		extraAddBindDataContext = data_transfer.DataArrayAddContext(i,as[i], consts.ValidatorPrefix, c)
		if extraAddBindDataContext == nil {
			response.ErrorSystem(c, "TaskAdd表单验证器json化失败", as[i])
		}
	}
	
	(&controller.DataFormat{}).Add(len(as),extraAddBindDataContext)
}
```


2.  model处 —— Add方法（某一个接收数组数据，并进行批量在数据库增加数据的方法）

```
func (d* DataFormatModel)Add(l int,c *gin.Context) error {
	ds := make([]DataFormatModel, l, 2*l)
	for i:=0;i<l;i++{
		data_bind.ShouldBindFormDataArrayToModel(i, c, &ds[i])
		println(ds[i].Name)
	}
	d.CreateInBatches(&ds,len(ds))
        return nil
}
``` 


zhangruiyuan@zju.edu.cn