### PR TITLE
处理custom_log读取配置文件bug

### DIFF
--- a/app/utils/gorm_v2/custom_log.go
+++ b/app/utils/gorm_v2/custom_log.go
@@ -23,7 +23,7 @@ func createCustomGormLog(sqlType string, options ...Options) gormLog.Interface {
 		traceErrStr  = "%s %s\n[%.3fms] [rows:%v] %s"
 	)
 	logConf := gormLog.Config{
-		SlowThreshold: time.Second * variable.ConfigGormv2Yml.GetDuration("Gormv2."+sqlType+"."+".SlowThreshold"),
+		SlowThreshold: time.Second * variable.ConfigGormv2Yml.GetDuration("Gormv2."+sqlType+".SlowThreshold"),
 		LogLevel:      gormLog.Warn,
 		Colorful:      false,
 	}


### PR DESCRIPTION
读取配置文件的字符串拼接错了，多拼了个点
